### PR TITLE
use cache sizes to select default thread count

### DIFF
--- a/src/qryptonight/qryptominer.cpp
+++ b/src/qryptonight/qryptominer.cpp
@@ -101,19 +101,20 @@ void Qryptominer::start(const std::vector<uint8_t> &input,
 
     if (thread_count==0)
     {
+        hwloc_obj_t cache;
         hwloc_topology_t topology;
         hwloc_topology_init(&topology);
         hwloc_topology_load(topology);
 
 #if HWLOC_API_VERSION >= 0x00020000
-        for (hwloc_obj_t cache = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_L4CACHE, NULL); cache; cache = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_L4CACHE, cache) )
+        for (cache = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_L4CACHE, NULL); cache; cache = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_L4CACHE, cache) )
         {
             thread_count += cache->attr->cache.size / 2097152;
         }
 
         if (!thread_count)
         {
-            for (hwloc_obj_t cache = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_L3CACHE, NULL); cache; cache = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_L3CACHE, cache) )
+            for (cache = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_L3CACHE, NULL); cache; cache = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_L3CACHE, cache) )
             {
                 thread_count += cache->attr->cache.size / 2097152;
             }
@@ -121,7 +122,7 @@ void Qryptominer::start(const std::vector<uint8_t> &input,
 
         if (!thread_count)
         {
-            for (hwloc_obj_t cache = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_L2CACHE, NULL); cache; cache = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_L2CACHE, cache) )
+            for (cache = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_L2CACHE, NULL); cache; cache = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_L2CACHE, cache) )
             {
                 thread_count += cache->attr->cache.size / 2097152;
             }

--- a/src/qryptonight/qryptominer.cpp
+++ b/src/qryptonight/qryptominer.cpp
@@ -103,8 +103,9 @@ void Qryptominer::start(const std::vector<uint8_t> &input,
     {
         hwloc_topology_t topology;
         hwloc_topology_init(&topology);
-        hwloc_topology_load(&topology);
+        hwloc_topology_load(topology);
 
+#if HWLOC_API_VERSION >= 0x00020000
         for (hwloc_obj_t cache = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_L4CACHE, NULL); cache; cache = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_L4CACHE, cache) )
         {
             thread_count += cache->attr->cache.size / 2097152;
@@ -125,6 +126,12 @@ void Qryptominer::start(const std::vector<uint8_t> &input,
                 thread_count += cache->attr->cache.size / 2097152;
             }
         }
+#else
+        for (hwloc_obj_t cache = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_CACHE, NULL); cache; cache = cache->next_cousin )
+        {
+            thread_count += cache->attr->cache.size / 2097152;
+        }
+#endif
 
         if (!thread_count || thread_count > 4 * std::thread::hardware_concurrency())
         {

--- a/src/qryptonight/qryptominer.cpp
+++ b/src/qryptonight/qryptominer.cpp
@@ -26,6 +26,7 @@
 #include <iostream>
 #include <chrono>
 #include <netinet/in.h>
+#include <hwloc.h>
 
 #define HASHRATE_MEASUREMENT_CYCLE 100
 #define HASHRATE_MEASUREMENT_FACTOR 10
@@ -100,7 +101,37 @@ void Qryptominer::start(const std::vector<uint8_t> &input,
 
     if (thread_count==0)
     {
-        thread_count = std::thread::hardware_concurrency();
+        hwloc_topology_t topology;
+        hwloc_topology_init(&topology);
+        hwloc_topology_load(&topology);
+
+        for (hwloc_obj_t cache = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_L4CACHE, NULL); cache; cache = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_L4CACHE, cache) )
+        {
+            thread_count += cache->attr->cache.size / 2097152;
+        }
+
+        if (!thread_count)
+        {
+            for (hwloc_obj_t cache = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_L3CACHE, NULL); cache; cache = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_L3CACHE, cache) )
+            {
+                thread_count += cache->attr->cache.size / 2097152;
+            }
+        }
+
+        if (!thread_count)
+        {
+            for (hwloc_obj_t cache = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_L2CACHE, NULL); cache; cache = hwloc_get_next_obj_by_type(topology, HWLOC_OBJ_L2CACHE, cache) )
+            {
+                thread_count += cache->attr->cache.size / 2097152;
+            }
+        }
+
+        if (!thread_count || thread_count > 4 * std::thread::hardware_concurrency())
+        {
+            thread_count = 4 * std::thread::hardware_concurrency();
+        }
+
+        hwloc_topology_destroy(topology);
     }
 
     for (uint32_t thread_idx = 0; thread_idx < thread_count; thread_idx++) {


### PR DESCRIPTION
sets default thread count based on cache sizes.
for CPUs with huge L4 caches, sets the default thread count to 4 times the number of physical cores.
if no caches large enough for cryptonight are detected by hwloc, falls back to using the number of physical cores.
code for the hwloc 2.0 API is still untested, but should work.
fixes #26.