### PR TITLE
Changed reference to copy from front() of _eventQueue

### DIFF
--- a/src/qryptonight/qryptominer.cpp
+++ b/src/qryptonight/qryptominer.cpp
@@ -209,7 +209,7 @@ void Qryptominer::_eventThreadWorker() {
                             [=] { return !_eventQueue.empty() || _stop_eventThread; });
 
         if (!_eventQueue.empty()) {
-            auto &event = _eventQueue.front();
+            auto event = _eventQueue.front();
             _eventQueue.pop_front();
             queue_lock.unlock();
             _solutionEvent(event.nonce, event.event_seq);

--- a/tests/python/test_qryptominer.py
+++ b/tests/python/test_qryptominer.py
@@ -26,7 +26,7 @@ class TestQryptominer(TestCase):
             0x1E, 0xE5, 0x3F, 0xE1, 0xAC, 0xF3, 0x55, 0x92,
             0x66, 0xD8, 0x43, 0x89, 0xCE, 0xDE, 0x99, 0x33,
             0xC6, 0x8F, 0xC5, 0x1E, 0xD0, 0xA6, 0xC7, 0x91,
-            0xF8, 0xF9, 0xE8, 0x9D, 0xB6, 0x23, 0xF0, 0xFF
+            0xF8, 0xF9, 0xE8, 0x9D, 0xB6, 0x23, 0xF0, 0x00
         ]
 
         # Create a customized miner
@@ -42,11 +42,11 @@ class TestQryptominer(TestCase):
         time.sleep(2)
 
         # This property has been just created in the python custom class when the event is received
-        self.assertEqual(1, qm.python_nonce)
+        self.assertEqual(6, qm.python_nonce)
 
         # Now check wrapper values
         self.assertEqual(True, qm.solutionAvailable())
-        self.assertEqual(1, qm.solutionNonce())
+        self.assertEqual(6, qm.solutionNonce())
 
     def test_miner_verify(self):
         class CustomQMiner(Qryptominer):


### PR DESCRIPTION
auto& event is a reference to the front of the queue, then the front element is removed (popped), then event member data is used. However, std::deque documentation for pop_front() states "iterators, pointers and references referring to the removed element are invalidated."
Therefore it is possible that the memory underneath event is reclaimed/reused for something else.
Most likely event's data is probably unchanged and the copy will be more expensive, but I feel it is worth fixing.