### PR TITLE
Implemented a pool of Qryptonight objects

### DIFF
--- a/src/pow/powhelper.cpp
+++ b/src/pow/powhelper.cpp
@@ -25,6 +25,8 @@
 #include "qryptonight.h"
 #include "misc/bignum.h"
 
+std::shared_ptr<QryptonightPool> PoWHelper::_qnpool = std::make_shared<QryptonightPool>();
+
 PoWHelper::PoWHelper(int64_t kp,
                      uint64_t set_point,
                      int64_t adjfact_lower,
@@ -111,7 +113,7 @@ bool PoWHelper::passesTarget(const std::vector<uint8_t> &hash, const std::vector
 
 bool PoWHelper::verifyInput(const std::vector<uint8_t> &input, const std::vector<uint8_t> &target)
 {
-    Qryptonight qn;
-    auto hash = qn.hash(input);
+    auto qn = _qnpool->acquire();
+    auto hash = qn->hash(input);
     return passesTarget(hash, target);
 }

--- a/src/pow/powhelper.cpp
+++ b/src/pow/powhelper.cpp
@@ -23,6 +23,7 @@
 
 #include "powhelper.h"
 #include "qryptonight.h"
+#include "qryptonightpool.h"
 #include "misc/bignum.h"
 
 std::shared_ptr<QryptonightPool> PoWHelper::_qnpool = std::make_shared<QryptonightPool>();

--- a/src/pow/powhelper.h
+++ b/src/pow/powhelper.h
@@ -42,10 +42,10 @@ public:
     std::vector<uint8_t> getDifficulty(uint64_t measurement,
                                        const std::vector<uint8_t> &parent_difficulty);
 
-    static std::vector<uint8_t> getTarget(const std::vector<uint8_t> &difficulty);
+    std::vector<uint8_t> getTarget(const std::vector<uint8_t> &difficulty);
 
     static bool passesTarget(const std::vector<uint8_t> &hash, const std::vector<uint8_t> &target);
-    static bool verifyInput(const std::vector<uint8_t> &input, const std::vector<uint8_t> &target);
+    bool verifyInput(const std::vector<uint8_t> &input, const std::vector<uint8_t> &target);
 
 private:
     long double _Kp;

--- a/src/pow/powhelper.h
+++ b/src/pow/powhelper.h
@@ -27,7 +27,9 @@
 #include <vector>
 #include <cstdint>
 #include <deque>
-#include <qryptonight/qryptonightpool.h>
+#include <memory>
+
+class QryptonightPool; // forward-declare this class to keep swig from including
 
 class PoWHelper {
 public:

--- a/src/pow/powhelper.h
+++ b/src/pow/powhelper.h
@@ -42,7 +42,7 @@ public:
     std::vector<uint8_t> getDifficulty(uint64_t measurement,
                                        const std::vector<uint8_t> &parent_difficulty);
 
-    std::vector<uint8_t> getTarget(const std::vector<uint8_t> &difficulty);
+    static std::vector<uint8_t> getTarget(const std::vector<uint8_t> &difficulty);
 
     static bool passesTarget(const std::vector<uint8_t> &hash, const std::vector<uint8_t> &target);
     static bool verifyInput(const std::vector<uint8_t> &input, const std::vector<uint8_t> &target);

--- a/src/pow/powhelper.h
+++ b/src/pow/powhelper.h
@@ -27,7 +27,7 @@
 #include <vector>
 #include <cstdint>
 #include <deque>
-#include <qryptonight/qryptonight.h>
+#include <qryptonight/qryptonightpool.h>
 
 class PoWHelper {
 public:
@@ -45,7 +45,7 @@ public:
     std::vector<uint8_t> getTarget(const std::vector<uint8_t> &difficulty);
 
     static bool passesTarget(const std::vector<uint8_t> &hash, const std::vector<uint8_t> &target);
-    bool verifyInput(const std::vector<uint8_t> &input, const std::vector<uint8_t> &target);
+    static bool verifyInput(const std::vector<uint8_t> &input, const std::vector<uint8_t> &target);
 
 private:
     long double _Kp;
@@ -54,7 +54,7 @@ private:
     int64_t _adjfact_upper;
     int64_t _adj_quantization;
 
-    Qryptonight _qn;
+    static std::shared_ptr<QryptonightPool> _qnpool;
 };
 
 #endif //QRYPTONIGHT_POW_Impl_H

--- a/src/qryptonight/qryptominer.cpp
+++ b/src/qryptonight/qryptominer.cpp
@@ -22,6 +22,8 @@
   */
 
 #include "qryptominer.h"
+#include "qryptonight.h"
+#include "qryptonightpool.h"
 #include "pow/powhelper.h"
 #include <iostream>
 #include <chrono>

--- a/src/qryptonight/qryptominer.h
+++ b/src/qryptonight/qryptominer.h
@@ -24,7 +24,7 @@
 #ifndef QRYPTONIGHT_QRYPTOMINER_H
 #define QRYPTONIGHT_QRYPTOMINER_H
 
-#include "qryptonight.h"
+#include "qryptonightpool.h"
 #include <atomic>
 #include <thread>
 #include <mutex>
@@ -93,6 +93,8 @@ protected:
     std::deque<MinerSolutionEvent> _eventQueue;
     std::mutex _eventQueue_mutex;
     std::condition_variable _eventReleased;
+	
+    static std::shared_ptr<QryptonightPool> _qnpool;
 };
 
 #endif //QRYPTONIGHT_QRYPTOMINER_H

--- a/src/qryptonight/qryptominer.h
+++ b/src/qryptonight/qryptominer.h
@@ -93,7 +93,7 @@ protected:
     std::deque<MinerSolutionEvent> _eventQueue;
     std::mutex _eventQueue_mutex;
     std::condition_variable _eventReleased;
-	
+
     static std::shared_ptr<QryptonightPool> _qnpool;
 };
 

--- a/src/qryptonight/qryptominer.h
+++ b/src/qryptonight/qryptominer.h
@@ -24,12 +24,14 @@
 #ifndef QRYPTONIGHT_QRYPTOMINER_H
 #define QRYPTONIGHT_QRYPTOMINER_H
 
-#include "qryptonightpool.h"
 #include <atomic>
 #include <thread>
 #include <mutex>
 #include <future>
 #include <deque>
+#include <vector>
+
+class QryptonightPool; // forward-declare this class to keep swig from including
 
 struct MinerSolutionEvent
 {

--- a/src/qryptonight/qryptonight.cpp
+++ b/src/qryptonight/qryptonight.cpp
@@ -54,7 +54,7 @@ Qryptonight::~Qryptonight()
     }
 }
 
-std::vector<uint8_t> Qryptonight::hash(std::vector<uint8_t> input)
+std::vector<uint8_t> Qryptonight::hash(const std::vector<uint8_t>& input)
 {
     std::vector<uint8_t> output(32);
 

--- a/src/qryptonight/qryptonight.h
+++ b/src/qryptonight/qryptonight.h
@@ -34,9 +34,9 @@ public:
     virtual ~Qryptonight();
 
     bool isValid() { return _context != nullptr; }
-    std::string lastError() { return std::string(_last_msg.warning); }
+    std::string lastError()	{ return std::string(_last_msg.warning ? _last_msg.warning : ""); }
 
-    std::vector<uint8_t> hash(std::vector<uint8_t> input);
+    std::vector<uint8_t> hash(const std::vector<uint8_t>& input);
 
 protected:
     alloc_msg _last_msg = { nullptr };

--- a/src/qryptonight/qryptonightpool.cpp
+++ b/src/qryptonight/qryptonightpool.cpp
@@ -47,9 +47,12 @@ void QryptonightPool::ReturnToPoolDeleter::detachFromPool()
 	_ptrToOwnerPool.reset();
 }
 
-QryptonightPool::QryptonightPool()
-	: _mutex()
-	, _poolContainer() { }
+QryptonightPool::QryptonightPool(QryptonightFactory factory)
+	: _factory(factory)
+	, _mutex()
+	, _poolContainer()
+{
+}
 
 QryptonightPool::~QryptonightPool()
 {
@@ -66,8 +69,9 @@ QryptonightPool::uniqueQryptonightPtr QryptonightPool::acquire()
 	std::unique_lock<std::mutex> lock(_mutex);
 	if (_poolContainer.empty())
 	{
-		// no Qryptonight intances availabe in the pool so create and return a new one
-		return uniqueQryptonightPtr{new Qryptonight(), ReturnToPoolDeleter(shared_from_this())};
+		// no Qryptonight intances availabe in the pool so use the factory to
+		// create and return a new one
+		return uniqueQryptonightPtr{_factory(), ReturnToPoolDeleter(shared_from_this())};
 	}
 	else
 	{

--- a/src/qryptonight/qryptonightpool.cpp
+++ b/src/qryptonight/qryptonightpool.cpp
@@ -1,0 +1,95 @@
+/*
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  *
+  * Additional permission under GNU GPL version 3 section 7
+  *
+  * If you modify this Program, or any covered work, by linking or combining
+  * it with OpenSSL (or a modified version of that library), containing parts
+  * covered by the terms of OpenSSL License and SSLeay License, the licensors
+  * of this Program grant you additional permission to convey the resulting work.
+  *
+  */
+
+#include "qryptonightpool.h"
+
+QryptonightPool::ReturnToPoolDeleter::ReturnToPoolDeleter(std::weak_ptr<QryptonightPool> pool)
+	: _pool(pool) { }
+
+void QryptonightPool::ReturnToPoolDeleter::operator()(Qryptonight* ptrToReleasedObject)
+{
+	if (auto pool = _pool.lock())
+	{
+		// the pool still exists so attempt to return it back to the pool
+		try
+		{
+			pool->add(uniqueQryptonightPtr{ptrToReleasedObject, ReturnToPoolDeleter(pool)});
+			return;
+		}
+		catch(const std::bad_alloc&) { }
+	}
+	// the pool is gone or cannot be added back so delete the object
+	delete ptrToReleasedObject;
+}
+
+void QryptonightPool::ReturnToPoolDeleter::detachFromPool()
+{
+	_pool.reset();
+}
+
+QryptonightPool::QryptonightPool()
+	: _mutex()
+	, _hashers() { }
+
+QryptonightPool::~QryptonightPool()
+{
+	std::unique_lock<std::mutex> lock(_mutex);
+	while (!_hashers.empty())
+	{
+		_hashers.top().get_deleter().detachFromPool();
+		_hashers.pop();
+	}
+}
+
+QryptonightPool::uniqueQryptonightPtr QryptonightPool::acquire()
+{
+	std::unique_lock<std::mutex> lock(_mutex);
+	if (_hashers.empty())
+	{
+		return uniqueQryptonightPtr{new Qryptonight(), ReturnToPoolDeleter(shared_from_this())};
+	}
+	else
+	{
+		auto ptr = std::move(_hashers.top());
+		_hashers.pop();
+		return ptr;
+	}
+}
+
+void QryptonightPool::add(QryptonightPool::uniqueQryptonightPtr ptr)
+{
+	std::unique_lock<std::mutex> lock(_mutex);
+	_hashers.push(std::move(ptr));
+}
+
+bool QryptonightPool::empty() const
+{
+	std::unique_lock<std::mutex> lock(_mutex);
+	return _hashers.empty();
+}
+
+size_t QryptonightPool::size() const
+{
+	std::unique_lock<std::mutex> lock(_mutex);
+	return _hashers.size();
+}

--- a/src/qryptonight/qryptonightpool.h
+++ b/src/qryptonight/qryptonightpool.h
@@ -31,6 +31,9 @@
 #include <functional>
 
 // An RAII-style object pool for memory-intensive Qryptonight objects
+// Warning! This class is not swig-compatible but does not need to be
+// exposed so make sure this class is not #included from a swig-included
+// header file
 class QryptonightPool : public std::enable_shared_from_this<QryptonightPool>
 {
 public:

--- a/src/qryptonight/qryptonightpool.h
+++ b/src/qryptonight/qryptonightpool.h
@@ -57,8 +57,8 @@ public:
 	// a std::unique_ptr with a custome deleter that the client will use
 	using uniqueQryptonightPtr = std::unique_ptr<Qryptonight, ReturnToPoolDeleter>;
 
-	// obtain an unused Qryptonight instance from the pool or create
-	// a new one if there are none available
+	// obtain an unused Qryptonight instance from the pool or
+	// create a new one if there are none available
 	uniqueQryptonightPtr acquire();
 
 	bool empty() const;
@@ -73,7 +73,7 @@ protected:
 	// factory function to create the Qryptonight objects
 	QryptonightFactory _factory;
 
-	// allow mutually exclusive access to _pool
+	// allow mutually exclusive access to _poolContainer
     mutable std::mutex _mutex;
 	
 	// container for the unused Qryptonight instances

--- a/src/qryptonight/qryptonightpool.h
+++ b/src/qryptonight/qryptonightpool.h
@@ -35,49 +35,49 @@ class QryptonightPool : public std::enable_shared_from_this<QryptonightPool>
 {
 public:
 
-	// a factory function to create new Qryptonight objects
-	using QryptonightFactory = std::function<Qryptonight*()>;
+    // a factory function to create new Qryptonight objects
+    using QryptonightFactory = std::function<Qryptonight*()>;
 
     QryptonightPool(QryptonightFactory factory = [](){ return new Qryptonight(); });
 
     virtual ~QryptonightPool();
 
-	// helper functor to return pointers back to the pool
-	// or delete the pointer if the pool no longer exists
-	class ReturnToPoolDeleter
-	{
-	public:
-		explicit ReturnToPoolDeleter(std::weak_ptr<QryptonightPool> ptrToOwnerPool);
-		void operator()(Qryptonight* ptrToReleasedObject);
-		void detachFromPool();
-	private:
-		std::weak_ptr<QryptonightPool> _ptrToOwnerPool;
-	};
+    // helper functor to return pointers back to the pool
+    // or delete the pointer if the pool no longer exists
+    class ReturnToPoolDeleter
+    {
+    public:
+        explicit ReturnToPoolDeleter(std::weak_ptr<QryptonightPool> ptrToOwnerPool);
+        void operator()(Qryptonight* ptrToReleasedObject);
+        void detachFromPool();
+    private:
+        std::weak_ptr<QryptonightPool> _ptrToOwnerPool;
+    };
 
-	// a std::unique_ptr with a custome deleter that the client will use
-	using uniqueQryptonightPtr = std::unique_ptr<Qryptonight, ReturnToPoolDeleter>;
+    // a std::unique_ptr with a custome deleter that the client will use
+    using uniqueQryptonightPtr = std::unique_ptr<Qryptonight, ReturnToPoolDeleter>;
 
-	// obtain an unused Qryptonight instance from the pool or
-	// create a new one if there are none available
-	uniqueQryptonightPtr acquire();
+    // obtain an unused Qryptonight instance from the pool or
+    // create a new one if there are none available
+    uniqueQryptonightPtr acquire();
 
-	bool empty() const;
-	
-	size_t size() const;
-		
+    bool empty() const;
+
+    size_t size() const;
+
 protected:
 
-	// return the Qryptonight instance back to the pool
-	void add(uniqueQryptonightPtr ptr);
-	
-	// factory function to create the Qryptonight objects
-	QryptonightFactory _factory;
+    // return the Qryptonight instance back to the pool
+    void add(uniqueQryptonightPtr ptr);
 
-	// allow mutually exclusive access to _poolContainer
+    // factory function to create the Qryptonight objects
+    QryptonightFactory _factory;
+
+    // allow mutually exclusive access to _poolContainer
     mutable std::mutex _mutex;
-	
-	// container for the unused Qryptonight instances
-	std::stack<uniqueQryptonightPtr> _poolContainer;
+
+    // container for the unused Qryptonight instances
+    std::stack<uniqueQryptonightPtr> _poolContainer;
 };
 
 #endif //QRYPTONIGHT_QRYPTONIGHTPOOL_H

--- a/src/qryptonight/qryptonightpool.h
+++ b/src/qryptonight/qryptonightpool.h
@@ -43,11 +43,11 @@ public:
 	class ReturnToPoolDeleter
 	{
 	public:
-		explicit ReturnToPoolDeleter(std::weak_ptr<QryptonightPool> pool);
+		explicit ReturnToPoolDeleter(std::weak_ptr<QryptonightPool> ptrToOwnerPool);
 		void operator()(Qryptonight* ptrToReleasedObject);
 		void detachFromPool();
 	private:
-		std::weak_ptr<QryptonightPool> _pool;	
+		std::weak_ptr<QryptonightPool> _ptrToOwnerPool;
 	};
 
 	// a std::unique_ptr with a custome deleter that the client will use
@@ -66,11 +66,11 @@ protected:
 	// return the Qryptonight instance back to the pool
 	void add(uniqueQryptonightPtr ptr);
 	
-	// allow mutually exclusive access to _hashers
+	// allow mutually exclusive access to _pool
     mutable std::mutex _mutex;
 	
-	// container for the pool of unused Qryptonight instances
-	std::stack<uniqueQryptonightPtr> _hashers;
+	// container for the unused Qryptonight instances
+	std::stack<uniqueQryptonightPtr> _poolContainer;
 };
 
 #endif //QRYPTONIGHT_QRYPTONIGHTPOOL_H

--- a/src/qryptonight/qryptonightpool.h
+++ b/src/qryptonight/qryptonightpool.h
@@ -1,0 +1,76 @@
+/*
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  *
+  * Additional permission under GNU GPL version 3 section 7
+  *
+  * If you modify this Program, or any covered work, by linking or combining
+  * it with OpenSSL (or a modified version of that library), containing parts
+  * covered by the terms of OpenSSL License and SSLeay License, the licensors
+  * of this Program grant you additional permission to convey the resulting work.
+  *
+  */
+
+#ifndef QRYPTONIGHT_QRYPTONIGHTPOOL_H
+#define QRYPTONIGHT_QRYPTONIGHTPOOL_H
+
+#include "qryptonight.h"
+#include <mutex>
+#include <stack>
+#include <memory>
+
+// An RAII-style object pool for memory-intensive Qryptonight objects
+class QryptonightPool : public std::enable_shared_from_this<QryptonightPool>
+{
+public:
+
+    QryptonightPool();
+
+    virtual ~QryptonightPool();
+
+	// helper functor to return pointers back to the pool
+	// or delete the pointer if the pool no longer exists
+	class ReturnToPoolDeleter
+	{
+	public:
+		explicit ReturnToPoolDeleter(std::weak_ptr<QryptonightPool> pool);
+		void operator()(Qryptonight* ptrToReleasedObject);
+		void detachFromPool();
+	private:
+		std::weak_ptr<QryptonightPool> _pool;	
+	};
+
+	// a std::unique_ptr with a custome deleter that the client will use
+	using uniqueQryptonightPtr = std::unique_ptr<Qryptonight, ReturnToPoolDeleter>;
+
+	// obtain an unused Qryptonight instance from the pool or create
+	// a new one if there are none available
+	uniqueQryptonightPtr acquire();
+	
+	bool empty() const;
+	
+	size_t size() const;
+		
+protected:
+
+	// return the Qryptonight instance back to the pool
+	void add(uniqueQryptonightPtr ptr);
+	
+	// allow mutually exclusive access to _hashers
+    mutable std::mutex _mutex;
+	
+	// container for the pool of unused Qryptonight instances
+	std::stack<uniqueQryptonightPtr> _hashers;
+};
+
+#endif //QRYPTONIGHT_QRYPTONIGHTPOOL_H

--- a/src/qryptonight/qryptonightpool.h
+++ b/src/qryptonight/qryptonightpool.h
@@ -28,13 +28,17 @@
 #include <mutex>
 #include <stack>
 #include <memory>
+#include <functional>
 
 // An RAII-style object pool for memory-intensive Qryptonight objects
 class QryptonightPool : public std::enable_shared_from_this<QryptonightPool>
 {
 public:
 
-    QryptonightPool();
+	// a factory function to create new Qryptonight objects
+	using QryptonightFactory = std::function<Qryptonight*()>;
+
+    QryptonightPool(QryptonightFactory factory = [](){ return new Qryptonight(); });
 
     virtual ~QryptonightPool();
 
@@ -56,7 +60,7 @@ public:
 	// obtain an unused Qryptonight instance from the pool or create
 	// a new one if there are none available
 	uniqueQryptonightPtr acquire();
-	
+
 	bool empty() const;
 	
 	size_t size() const;
@@ -66,6 +70,9 @@ protected:
 	// return the Qryptonight instance back to the pool
 	void add(uniqueQryptonightPtr ptr);
 	
+	// factory function to create the Qryptonight objects
+	QryptonightFactory _factory;
+
 	// allow mutually exclusive access to _pool
     mutable std::mutex _mutex;
 	

--- a/tests/cpp/qryptonightpool.cpp
+++ b/tests/cpp/qryptonightpool.cpp
@@ -25,22 +25,22 @@
 #include "gtest/gtest.h"
 
 namespace {
-	
-	class QryptonightWithRefCount : public Qryptonight
-	{
-	public:
-		QryptonightWithRefCount() : Qryptonight() { ++_instances; }
-		virtual ~QryptonightWithRefCount() { --_instances; }
-		static size_t _instances;
-	};
-	
-	size_t QryptonightWithRefCount::_instances = 0;
-	
-	QryptonightPool::QryptonightFactory factory =
-		[](){ return new QryptonightWithRefCount(); };
 
-	void ValidateHash(QryptonightPool::uniqueQryptonightPtr& qn)
-	{
+    class QryptonightWithRefCount : public Qryptonight
+    {
+    public:
+        QryptonightWithRefCount() : Qryptonight() { ++_instances; }
+        virtual ~QryptonightWithRefCount() { --_instances; }
+        static size_t _instances;
+    };
+
+    size_t QryptonightWithRefCount::_instances = 0;
+
+    QryptonightPool::QryptonightFactory factory =
+        [](){ return new QryptonightWithRefCount(); };
+
+    void ValidateHash(QryptonightPool::uniqueQryptonightPtr& qn)
+    {
         EXPECT_TRUE(qn->isValid());
 
         std::vector<uint8_t> input {
@@ -57,13 +57,13 @@ namespace {
         auto output = qn->hash(input);
 
         EXPECT_EQ(output_expected, output);
-	}
-	
+    }
+
     TEST(QryptoNightPool, Init) {
         auto pool = std::make_shared<QryptonightPool>(factory);
         EXPECT_TRUE(pool->empty());
         EXPECT_EQ(pool->size(), 0);
-		EXPECT_EQ(QryptonightWithRefCount::_instances, 0);
+        EXPECT_EQ(QryptonightWithRefCount::_instances, 0);
     }
 
     TEST(QryptoNightPool, Empty) {
@@ -71,38 +71,38 @@ namespace {
 
         auto qn = pool->acquire();
         EXPECT_TRUE(pool->empty());
-		EXPECT_EQ(QryptonightWithRefCount::_instances, 1);
-		
-		qn.reset();
+        EXPECT_EQ(QryptonightWithRefCount::_instances, 1);
+
+        qn.reset();
         EXPECT_FALSE(pool->empty());
-		EXPECT_EQ(QryptonightWithRefCount::_instances, 1);
-	}
+        EXPECT_EQ(QryptonightWithRefCount::_instances, 1);
+    }
 
     TEST(QryptoNightPool, AcquireHashReleaseCycle) {
         auto pool = std::make_shared<QryptonightPool>(factory);
 
         auto qn = pool->acquire();
         EXPECT_EQ(pool->size(), 0);
-		EXPECT_EQ(QryptonightWithRefCount::_instances, 1);
+        EXPECT_EQ(QryptonightWithRefCount::_instances, 1);
 
-		ValidateHash(qn);
+        ValidateHash(qn);
 
-		qn.reset();
+        qn.reset();
         EXPECT_EQ(pool->size(), 1);
-		EXPECT_EQ(QryptonightWithRefCount::_instances, 1);
+        EXPECT_EQ(QryptonightWithRefCount::_instances, 1);
 
-		qn = pool->acquire();
+        qn = pool->acquire();
         EXPECT_EQ(pool->size(), 0);
-		EXPECT_EQ(QryptonightWithRefCount::_instances, 1);
-		
-		ValidateHash(qn);
+        EXPECT_EQ(QryptonightWithRefCount::_instances, 1);
 
-		qn.reset();
+        ValidateHash(qn);
+
+        qn.reset();
         EXPECT_EQ(pool->size(), 1);
-		EXPECT_EQ(QryptonightWithRefCount::_instances, 1);
+        EXPECT_EQ(QryptonightWithRefCount::_instances, 1);
 
-		pool.reset();
-		EXPECT_EQ(QryptonightWithRefCount::_instances, 0);
+        pool.reset();
+        EXPECT_EQ(QryptonightWithRefCount::_instances, 0);
     }
 
     TEST(QryptoNightPool, AcquireHashReleaseFour) {
@@ -113,22 +113,22 @@ namespace {
         auto qn3 = pool->acquire();
         auto qn4 = pool->acquire();
         EXPECT_EQ(pool->size(), 0);
-		EXPECT_EQ(QryptonightWithRefCount::_instances, 4);
+        EXPECT_EQ(QryptonightWithRefCount::_instances, 4);
 
-		ValidateHash(qn1);
-		ValidateHash(qn2);
-		ValidateHash(qn3);
-		ValidateHash(qn4);
+        ValidateHash(qn1);
+        ValidateHash(qn2);
+        ValidateHash(qn3);
+        ValidateHash(qn4);
 
-		qn1.reset();
-		qn2.reset();
-		qn3.reset();
-		qn4.reset();
+        qn1.reset();
+        qn2.reset();
+        qn3.reset();
+        qn4.reset();
         EXPECT_EQ(pool->size(), 4);
-		EXPECT_EQ(QryptonightWithRefCount::_instances, 4);
-		
-		pool.reset();
-		EXPECT_EQ(QryptonightWithRefCount::_instances, 0);
+        EXPECT_EQ(QryptonightWithRefCount::_instances, 4);
+
+        pool.reset();
+        EXPECT_EQ(QryptonightWithRefCount::_instances, 0);
     }
 
     TEST(QryptoNightPool, AcquireAndDeletePool) {
@@ -136,17 +136,17 @@ namespace {
 
         auto qn = pool->acquire();
         EXPECT_EQ(pool->size(), 0);
-		EXPECT_EQ(QryptonightWithRefCount::_instances, 1);
+        EXPECT_EQ(QryptonightWithRefCount::_instances, 1);
 
-		pool.reset();
+        pool.reset();
 
-		EXPECT_EQ(QryptonightWithRefCount::_instances, 1);
+        EXPECT_EQ(QryptonightWithRefCount::_instances, 1);
 
-		ValidateHash(qn);
+        ValidateHash(qn);
 
-		qn.reset();
-		
-		EXPECT_EQ(QryptonightWithRefCount::_instances, 0);
+        qn.reset();
+
+        EXPECT_EQ(QryptonightWithRefCount::_instances, 0);
     }
 
 }

--- a/tests/cpp/qryptonightpool.cpp
+++ b/tests/cpp/qryptonightpool.cpp
@@ -1,0 +1,139 @@
+/*
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  *
+  * Additional permission under GNU GPL version 3 section 7
+  *
+  * If you modify this Program, or any covered work, by linking or combining
+  * it with OpenSSL (or a modified version of that library), containing parts
+  * covered by the terms of OpenSSL License and SSLeay License, the licensors
+  * of this Program grant you additional permission to convey the resulting work.
+  *
+  */
+#include <iostream>
+#include <qryptonight/qryptonightpool.h>
+#include "gtest/gtest.h"
+
+namespace {
+    TEST(QryptoNightPool, Init) {
+        auto pool = std::make_shared<QryptonightPool>();
+        EXPECT_TRUE(pool->empty());
+        EXPECT_EQ(pool->size(), 0);
+    }
+
+    TEST(QryptoNightPool, AcquireAndRunSingleHash) {
+        auto pool = std::make_shared<QryptonightPool>();
+        EXPECT_TRUE(pool->empty());
+
+        auto qn = pool->acquire();
+        EXPECT_TRUE(pool->empty());
+        EXPECT_EQ(pool->size(), 0);
+        EXPECT_TRUE(qn->isValid());
+
+        std::vector<uint8_t> input {
+                0x03, 0x05, 0x07, 0x09
+        };
+
+        std::vector<uint8_t> output_expected {
+                0x3E, 0xE5, 0x3F, 0xE1, 0xAC, 0xF3, 0x55, 0x92,
+                0x66, 0xD8, 0x43, 0x89, 0xCE, 0xDE, 0x99, 0x33,
+                0xC6, 0x8F, 0xC5, 0x1E, 0xD0, 0xA6, 0xC7, 0x91,
+                0xF8, 0xF9, 0xE8, 0x9D, 0xB6, 0x23, 0xF0, 0xF6
+        };
+
+        auto output = qn->hash(input);
+
+        EXPECT_EQ(output_expected, output);
+
+		qn.reset();
+        EXPECT_FALSE(pool->empty());
+        EXPECT_EQ(pool->size(), 1);
+		
+		pool.reset();
+    }
+
+    TEST(QryptoNightPool, AcquireAndRunSingleHashTwice) {
+        auto pool = std::make_shared<QryptonightPool>();
+        EXPECT_TRUE(pool->empty());
+
+        auto qn = pool->acquire();
+        EXPECT_TRUE(pool->empty());
+        EXPECT_EQ(pool->size(), 0);
+        EXPECT_TRUE(qn->isValid());
+
+        std::vector<uint8_t> input {
+                0x03, 0x05, 0x07, 0x09
+        };
+
+        std::vector<uint8_t> output_expected {
+                0x3E, 0xE5, 0x3F, 0xE1, 0xAC, 0xF3, 0x55, 0x92,
+                0x66, 0xD8, 0x43, 0x89, 0xCE, 0xDE, 0x99, 0x33,
+                0xC6, 0x8F, 0xC5, 0x1E, 0xD0, 0xA6, 0xC7, 0x91,
+                0xF8, 0xF9, 0xE8, 0x9D, 0xB6, 0x23, 0xF0, 0xF6
+        };
+
+        auto output = qn->hash(input);
+
+        EXPECT_EQ(output_expected, output);
+
+		qn.reset();
+        EXPECT_FALSE(pool->empty());
+        EXPECT_EQ(pool->size(), 1);
+
+        qn = std::move(pool->acquire());
+        EXPECT_TRUE(pool->empty());
+        EXPECT_EQ(pool->size(), 0);
+        EXPECT_TRUE(qn->isValid());
+
+        output = qn->hash(input);
+
+        EXPECT_EQ(output_expected, output);
+
+		qn.reset();
+        EXPECT_FALSE(pool->empty());
+        EXPECT_EQ(pool->size(), 1);
+		
+		pool.reset();
+    }
+
+    TEST(QryptoNightPool, AcquireAndDeletePool) {
+        auto pool = std::make_shared<QryptonightPool>();
+        EXPECT_TRUE(pool->empty());
+
+        auto qn = pool->acquire();
+        EXPECT_TRUE(pool->empty());
+        EXPECT_EQ(pool->size(), 0);
+        EXPECT_TRUE(qn->isValid());
+
+		pool.reset();
+
+        std::vector<uint8_t> input {
+                0x03, 0x05, 0x07, 0x09
+        };
+
+        std::vector<uint8_t> output_expected {
+                0x3E, 0xE5, 0x3F, 0xE1, 0xAC, 0xF3, 0x55, 0x92,
+                0x66, 0xD8, 0x43, 0x89, 0xCE, 0xDE, 0x99, 0x33,
+                0xC6, 0x8F, 0xC5, 0x1E, 0xD0, 0xA6, 0xC7, 0x91,
+                0xF8, 0xF9, 0xE8, 0x9D, 0xB6, 0x23, 0xF0, 0xF6
+        };
+
+        auto output = qn->hash(input);
+
+        EXPECT_EQ(output_expected, output);
+
+		qn.reset();
+    }
+
+
+}


### PR DESCRIPTION
An attempt to resolve #34.  Creates a thread-safe, RAII-style pool of Qryptonight objects for re-use across invocations within both Qryptominer and PoWHelper.
It is important to note the pool class is not swig-compatible so it should not be included in any header file.  This should be ok since the pool does not need to be exposed in the api.

Before the change the unit tests with valgrind (memcheck) show:
```
==18970== HEAP SUMMARY:
==18970==     in use at exit: 352 bytes in 4 blocks
==18970==   total heap usage: 1,541 allocs, 1,537 frees, 128,278,126 bytes allocated
==18970== 
==18970== LEAK SUMMARY:
==18970==    definitely lost: 0 bytes in 0 blocks
==18970==    indirectly lost: 0 bytes in 0 blocks
==18970==      possibly lost: 0 bytes in 0 blocks
==18970==    still reachable: 352 bytes in 4 blocks
==18970==         suppressed: 0 bytes in 0 blocks
```
With this change (and skipping the new unit tests for the pool) show much less total heap bytes allocated:
```
==9227== HEAP SUMMARY:
==9227==     in use at exit: 352 bytes in 4 blocks
==9227==   total heap usage: 1,361 allocs, 1,357 frees, 17,104,682 bytes allocated
==9227== 
==9227== LEAK SUMMARY:
==9227==    definitely lost: 0 bytes in 0 blocks
==9227==    indirectly lost: 0 bytes in 0 blocks
==9227==      possibly lost: 0 bytes in 0 blocks
==9227==    still reachable: 352 bytes in 4 blocks
==9227==         suppressed: 0 bytes in 0 blocks
```