### PR TITLE
Fix: Pass Target when mined hash equals to target

### DIFF
--- a/src/pow/powhelper.cpp
+++ b/src/pow/powhelper.cpp
@@ -96,7 +96,7 @@ std::vector<uint8_t> PoWHelper::getTarget(const std::vector<uint8_t> &difficulty
 
 bool PoWHelper::passesTarget(const std::vector<uint8_t> &hash, const std::vector<uint8_t> &target)
 {
-    // The hash needs to be below the target (both 32 bytes)
+    // The hash needs to be below or equals to the target (both 32 bytes)
     // Monero uses little endian.. we need to check in reverse order
     for(size_t i = 0; i < 32; i++)
     {
@@ -109,7 +109,7 @@ bool PoWHelper::passesTarget(const std::vector<uint8_t> &hash, const std::vector
             return true;
     }
 
-    return false;  // they are equal
+    return true;  // they are equal
 }
 
 bool PoWHelper::verifyInput(const std::vector<uint8_t> &input, const std::vector<uint8_t> &target)

--- a/tests/cpp/qryptominer.cpp
+++ b/tests/cpp/qryptominer.cpp
@@ -37,7 +37,7 @@ namespace {
             0xF8, 0xF9, 0xE8, 0x9D, 0xB6, 0x23, 0xF0, 0xF6
         };
 
-        ASSERT_FALSE(PoWHelper::passesTarget(target, target));
+        ASSERT_TRUE(PoWHelper::passesTarget(target, target));
 
         std::cout << std::endl;
         std::cout << printByteVector2(target) << std::endl;


### PR DESCRIPTION
Cryptonote and other pools, expect target as passed if the mined hash greater than or equals to target. This is a fix to return true, for the case, when mined hash equals to the target.