### PR TITLE
Avoid reading config on every instantiation

### DIFF
--- a/src/qryptonight/qryptonight.cpp
+++ b/src/qryptonight/qryptonight.cpp
@@ -30,7 +30,7 @@
 Qryptonight::Qryptonight()
 {
     size_t init_res;
-    jconf::inst()->parse_config("", "");
+    init();
 
     // First try fast mem
     init_res = cryptonight_init(1, 1, &_last_msg);
@@ -46,6 +46,17 @@ Qryptonight::Qryptonight()
     // If something failed.. go for basic settings
     init_res = cryptonight_init(0, 1, &_last_msg);
     _context = cryptonight_alloc_ctx(0, 1, &_last_msg);
+}
+
+std::atomic_bool Qryptonight::_jconf_initialized { false };
+
+void Qryptonight::init()
+{
+    if (!_jconf_initialized)
+    {
+        _jconf_initialized = true;
+        jconf::inst()->parse_config("", "");
+    }
 }
 
 Qryptonight::~Qryptonight()

--- a/src/qryptonight/qryptonight.h
+++ b/src/qryptonight/qryptonight.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <stdexcept>
 #include <xmrstak/backend/cpu/crypto/cryptonight_types.h>
+#include <atomic>
 
 class Qryptonight {
 public:
@@ -40,6 +41,9 @@ public:
     std::vector<uint8_t> hash(const std::vector<uint8_t>& input) throw(std::invalid_argument);
 
 protected:
+    static void init();
+    static std::atomic_bool _jconf_initialized;
+
     alloc_msg _last_msg = { nullptr };
     cryptonight_ctx *_context;
 };


### PR DESCRIPTION
jconf singleton was reading a configuration on every instantiation