### PR TITLE
Fix for deadlocked test

### DIFF
--- a/src/qryptonight/qryptominer.cpp
+++ b/src/qryptonight/qryptominer.cpp
@@ -64,8 +64,11 @@ Qryptominer::Qryptominer()
 Qryptominer::~Qryptominer()
 {
     cancel();
-    _stop_eventThread = true;
-    _eventReleased.notify_one();
+    {
+        std::lock_guard<std::mutex> lock_queue(_eventQueue_mutex);
+        _stop_eventThread = true;
+        _eventReleased.notify_one();
+    }
     _eventThread->join();
 }
 
@@ -105,7 +108,7 @@ uint32_t Qryptominer::solutionNonce()
 
 std::vector<uint8_t> Qryptominer::solutionHash()
 {
-    std::lock_guard<std::recursive_timed_mutex> lock(_solution_mutex);
+    std::lock_guard<std::mutex> lock_queue(_eventQueue_mutex);
     return _solution_hash;
 }
 

--- a/src/qryptonight/qryptominer.cpp
+++ b/src/qryptonight/qryptominer.cpp
@@ -108,7 +108,7 @@ uint32_t Qryptominer::solutionNonce()
 
 std::vector<uint8_t> Qryptominer::solutionHash()
 {
-    std::lock_guard<std::mutex> lock_queue(_eventQueue_mutex);
+    std::lock_guard<std::recursive_timed_mutex> lock(_solution_mutex);
     return _solution_hash;
 }
 

--- a/tests/cpp/qryptominer.cpp
+++ b/tests/cpp/qryptominer.cpp
@@ -198,7 +198,7 @@ TEST(Qryptominer, RunAndRestart)
     };
 
     qm.start(input, 0, boundary);
-    qm.waitForAnswer(15);
+    qm.waitForAnswer(20);
 
     ASSERT_TRUE(qm.solutionAvailable());
     EXPECT_EQ(37, qm.solutionNonce());


### PR DESCRIPTION
Fixes #37.  Wraps the Qryptominer destructor call to notify_one with the same mutex as the wait().  I was able to run the tests in a loop over the weekend with this change whereas without, the tests would freeze on my system within minutes.