### PR TITLE
Minor bug fix for building from Source on Windows

### DIFF
--- a/src/qryptonight/qryptonight.cpp
+++ b/src/qryptonight/qryptonight.cpp
@@ -27,6 +27,12 @@
 #include <xmrstak/jconf.hpp>
 #include "qryptonight.h"
 
+#ifdef _WIN32
+#include <Windows.h>
+#include <shellapi.h>
+#include <xmrstak/misc/uac.cpp>
+#endif
+
 Qryptonight::Qryptonight()
 {
     size_t init_res;


### PR DESCRIPTION
Fix for "error LNK2019: unresolved external symbol of "void __cdecl RequestElevation(void)" on Windows (both Ninja Build and Microsoft MSBuild).