### PR TITLE
Update branch for Googletest

### DIFF
--- a/CMakeLists.txt.gtest.in
+++ b/CMakeLists.txt.gtest.in
@@ -1,4 +1,4 @@
-# Based on https://github.com/google/googletest/tree/master/googletest#incorporating-into-an-existing-cmake-project
+# Based on https://github.com/google/googletest/tree/main/googletest#incorporating-into-an-existing-cmake-project
 cmake_minimum_required(VERSION 2.8.2)
 
 project(googletest-download NONE)
@@ -6,7 +6,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
         GIT_REPOSITORY    https://github.com/google/googletest.git
-        GIT_TAG           master
+        GIT_TAG           main
         SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
         BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
         CONFIGURE_COMMAND ""


### PR DESCRIPTION
When running cmake, it will fail to on the download step for googletest: 
```
[ 22%] Performing download step (git clone) for 'googletest'
Cloning into 'googletest-src'...
fatal: invalid reference: master
CMake Error at googletest-download/googletest-prefix/tmp/googletest-gitclone.cmake:40 (message):
  Failed to checkout tag: 'master'


gmake[2]: *** [CMakeFiles/googletest.dir/build.make:99: googletest-prefix/src/googletest-stamp/googletest-download] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/googletest.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2
CMake Error at CMakeLists.txt:182 (message):
  Build step for googletest failed: 2


-- Configuring incomplete, errors occurred!
```
This is due to it trying to fetch the branch "master", which has been renamed to "main". This commit updates the repository name so that it will fetch it again. 