### PR TITLE
Automatically use software AES when hardware AES is not supported

### DIFF
--- a/src/qryptonight/qryptonight.cpp
+++ b/src/qryptonight/qryptonight.cpp
@@ -57,6 +57,13 @@ void Qryptonight::init()
         _jconf_initialized = true;
         jconf::inst()->parse_config("", "");
     }
+
+    cn_hash_fn hash_impls[] = {
+	hash_impl<false>,
+	hash_impl<true>
+    };
+    
+    hash = hash_impls[jconf::inst()->HaveHardwareAes()];
 }
 
 Qryptonight::~Qryptonight()
@@ -67,7 +74,8 @@ Qryptonight::~Qryptonight()
     }
 }
 
-std::vector<uint8_t> Qryptonight::hash(const std::vector<uint8_t>& input)
+template<bool SOFT_AES>
+std::vector<uint8_t> Qryptonight::hash_impl(const std::vector<uint8_t>& input)
 {
     std::vector<uint8_t> output(32);
 
@@ -79,9 +87,9 @@ std::vector<uint8_t> Qryptonight::hash(const std::vector<uint8_t>& input)
         throw std::invalid_argument("input length should be > 42 bytes");
     }
 
-    cryptonight_hash<cryptonight_monero, false, false>(input.data(), input.size(),
-                                                       output.data(),
-                                                       _context);
+    cryptonight_hash<cryptonight_monero, SOFT_AES, false>(input.data(), input.size(),
+							  output.data(),
+							  _context);
 
     return output;
 };

--- a/src/qryptonight/qryptonight.cpp
+++ b/src/qryptonight/qryptonight.cpp
@@ -57,6 +57,13 @@ void Qryptonight::init()
         _jconf_initialized = true;
         jconf::inst()->parse_config("", "");
     }
+
+    cn_hash_impl hash_impls[] = {
+        cryptonight_hash<cryptonight_monero, true, false>,
+        cryptonight_hash<cryptonight_monero, false, false>
+    };
+    
+    cn_hash_fn = hash_impls[jconf::inst()->HaveHardwareAes()];
 }
 
 Qryptonight::~Qryptonight()
@@ -79,14 +86,9 @@ std::vector<uint8_t> Qryptonight::hash(const std::vector<uint8_t>& input)
         throw std::invalid_argument("input length should be > 42 bytes");
     }
 
-    cn_hash_impl hash_impls[] = {
-        cryptonight_hash<cryptonight_monero, true, false>,
-        cryptonight_hash<cryptonight_monero, false, false>
-    };
-
-    hash_impls[jconf::inst()->HaveHardwareAes()](input.data(), input.size(),
-						 output.data(),
-						 _context);
+    cn_hash_fn(input.data(), input.size(),
+	       output.data(),
+	       _context);
 
     return output;
 };

--- a/src/qryptonight/qryptonight.cpp
+++ b/src/qryptonight/qryptonight.cpp
@@ -49,11 +49,11 @@ Qryptonight::Qryptonight()
 }
 
 std::atomic_bool Qryptonight::_jconf_initialized { false };
-Qryptonight::hash_impl Qryptonight::_hash_fn { NULL };
+Qryptonight::cn_hash_fn Qryptonight::_hash_fn { NULL };
 
 void Qryptonight::init()
 {
-    static const hash_impl hash_impls[] = {
+    static const cn_hash_fn hash_impls[] = {
         cryptonight_hash<cryptonight_monero, true, false>,
         cryptonight_hash<cryptonight_monero, false, false>
     };
@@ -62,7 +62,7 @@ void Qryptonight::init()
     {
         _jconf_initialized = true;
         jconf::inst()->parse_config("", "");
-
+	
 	_hash_fn = hash_impls[jconf::inst()->HaveHardwareAes()];
     }
 }

--- a/src/qryptonight/qryptonight.cpp
+++ b/src/qryptonight/qryptonight.cpp
@@ -57,13 +57,6 @@ void Qryptonight::init()
         _jconf_initialized = true;
         jconf::inst()->parse_config("", "");
     }
-
-    cn_hash_fn hash_impls[] = {
-	hash_impl<false>,
-	hash_impl<true>
-    };
-    
-    hash = hash_impls[jconf::inst()->HaveHardwareAes()];
 }
 
 Qryptonight::~Qryptonight()
@@ -74,8 +67,7 @@ Qryptonight::~Qryptonight()
     }
 }
 
-template<bool SOFT_AES>
-std::vector<uint8_t> Qryptonight::hash_impl(const std::vector<uint8_t>& input)
+std::vector<uint8_t> Qryptonight::hash(const std::vector<uint8_t>& input)
 {
     std::vector<uint8_t> output(32);
 
@@ -87,9 +79,14 @@ std::vector<uint8_t> Qryptonight::hash_impl(const std::vector<uint8_t>& input)
         throw std::invalid_argument("input length should be > 42 bytes");
     }
 
-    cryptonight_hash<cryptonight_monero, SOFT_AES, false>(input.data(), input.size(),
-							  output.data(),
-							  _context);
+    cn_hash_impl hash_impls[] = {
+        cryptonight_hash<cryptonight_monero, true, false>,
+        cryptonight_hash<cryptonight_monero, false, false>
+    };
+
+    hash_impls[jconf::inst()->HaveHardwareAes()](input.data(), input.size(),
+						 output.data(),
+						 _context);
 
     return output;
 };

--- a/src/qryptonight/qryptonight.h
+++ b/src/qryptonight/qryptonight.h
@@ -38,12 +38,8 @@ public:
     bool isValid() { return _context != nullptr; }
     std::string lastError()	{ return std::string(_last_msg.warning ? _last_msg.warning : ""); }
 
-    typedef std::vector<uint8_t> (Qryptonight::*cn_hash_fn)(const std::vector<uint8_t>&);
-    
-    template<bool SOFT_AES>
-    std::vector<uint8_t> hash_impl(const std::vector<uint8_t>& input);
-    
-    cn_hash_fn hash;
+    typedef void (*cn_hash_impl)(const void* input, size_t len, void* output, cryptonight_ctx* ctx0);
+    std::vector<uint8_t> hash(const std::vector<uint8_t>& input);
 
 protected:
     static void init();

--- a/src/qryptonight/qryptonight.h
+++ b/src/qryptonight/qryptonight.h
@@ -41,8 +41,8 @@ public:
     std::vector<uint8_t> hash(const std::vector<uint8_t>& input);
 
 protected:
-    typedef void (*cn_hash_impl)(const void* input, size_t len, void* output, cryptonight_ctx* ctx0);
-    static bool use_hardware_aes;
+    typedef void (*hash_impl)(const void* input, size_t len, void* output, cryptonight_ctx* ctx0);
+    static hash_impl _hash_fn;
     
     static void init();
     static std::atomic_bool _jconf_initialized;

--- a/src/qryptonight/qryptonight.h
+++ b/src/qryptonight/qryptonight.h
@@ -41,6 +41,7 @@ public:
     std::vector<uint8_t> hash(const std::vector<uint8_t>& input);
 
 protected:
+    //Protected variables are prefixed with an underscore
     typedef void (*cn_hash_fn)(const void* input, size_t len, void* output, cryptonight_ctx* ctx0);
     static cn_hash_fn _hash_fn;
     

--- a/src/qryptonight/qryptonight.h
+++ b/src/qryptonight/qryptonight.h
@@ -41,8 +41,8 @@ public:
     std::vector<uint8_t> hash(const std::vector<uint8_t>& input);
 
 protected:
-    typedef void (*hash_impl)(const void* input, size_t len, void* output, cryptonight_ctx* ctx0);
-    static hash_impl _hash_fn;
+    typedef void (*cn_hash_fn)(const void* input, size_t len, void* output, cryptonight_ctx* ctx0);
+    static cn_hash_fn _hash_fn;
     
     static void init();
     static std::atomic_bool _jconf_initialized;

--- a/src/qryptonight/qryptonight.h
+++ b/src/qryptonight/qryptonight.h
@@ -38,11 +38,13 @@ public:
     bool isValid() { return _context != nullptr; }
     std::string lastError()	{ return std::string(_last_msg.warning ? _last_msg.warning : ""); }
 
-    typedef void (*cn_hash_impl)(const void* input, size_t len, void* output, cryptonight_ctx* ctx0);
     std::vector<uint8_t> hash(const std::vector<uint8_t>& input);
 
 protected:
-    static void init();
+    typedef void (*cn_hash_impl)(const void* input, size_t len, void* output, cryptonight_ctx* ctx0);
+    cn_hash_impl cn_hash_fn;
+    
+    void init();
     static std::atomic_bool _jconf_initialized;
 
     alloc_msg _last_msg = { nullptr };

--- a/src/qryptonight/qryptonight.h
+++ b/src/qryptonight/qryptonight.h
@@ -42,9 +42,9 @@ public:
 
 protected:
     typedef void (*cn_hash_impl)(const void* input, size_t len, void* output, cryptonight_ctx* ctx0);
-    cn_hash_impl cn_hash_fn;
+    static bool use_hardware_aes;
     
-    void init();
+    static void init();
     static std::atomic_bool _jconf_initialized;
 
     alloc_msg _last_msg = { nullptr };

--- a/src/qryptonight/qryptonight.h
+++ b/src/qryptonight/qryptonight.h
@@ -38,7 +38,12 @@ public:
     bool isValid() { return _context != nullptr; }
     std::string lastError()	{ return std::string(_last_msg.warning ? _last_msg.warning : ""); }
 
-    std::vector<uint8_t> hash(const std::vector<uint8_t>& input);
+    typedef std::vector<uint8_t> (Qryptonight::*cn_hash_fn)(const std::vector<uint8_t>&);
+    
+    template<bool SOFT_AES>
+    std::vector<uint8_t> hash_impl(const std::vector<uint8_t>& input);
+    
+    cn_hash_fn hash;
 
 protected:
     static void init();


### PR DESCRIPTION
Enables QRL node to run on both computers with and without AES at optimal performance, by enabling hardware AES if it is supported, and using a software implementation if it is not, fixing https://github.com/theQRL/qryptonight/issues/29. 

Am I correct that the coding style here, is to prefix protected variables with an underscore? 

I have not added an underscore to the function pointer, as it feels weirdly redundant to have two underscored names in a row, and because init() is not prefixed with an underscore. 

Hopefully this fits well. 

Testing of both possible implementations of _hash_fn is not currently implemented, as, to my understanding, the tests appear to be for the wrapper of the function, rather than the downstream XMR-Stak one. 