### PR TITLE
Modification for Raspberry Pi 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "deps/xmr-stak"]
 	path = deps/xmr-stak
 	url = https://github.com/jleni/xmr-stak.git
+[submodule "deps/py-qryptonight"]
+	path = deps/py-qryptonight
+	url = https://github.com/0xFF0/py-qryptonight.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "deps/xmr-stak"]
 	path = deps/xmr-stak
 	url = https://github.com/jleni/xmr-stak.git
-[submodule "deps/py-cryptonight"]
-	path = deps/py-cryptonight
-	url = https://github.com/0xFF0/py-cryptonight.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/jleni/xmr-stak.git
 [submodule "deps/py-cryptonight"]
 	path = deps/py-cryptonight
-	url = https://github.com/0xFF0/py-cryptonight.git
+	url = https://github.com/0xFF0/py-cryptonight

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/xmr-stak"]
 	path = deps/xmr-stak
 	url = https://github.com/jleni/xmr-stak.git
-[submodule "py-cryptonight"]
-	path = py-cryptonight
+[submodule "deps/py-cryptonight"]
+	path = deps/py-cryptonight
 	url = https://github.com/0xFF0/py-cryptonight.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/xmr-stak"]
 	path = deps/xmr-stak
 	url = https://github.com/jleni/xmr-stak.git
-[submodule "deps/py-qryptonight"]
-	path = deps/py-qryptonight
-	url = https://github.com/0xFF0/py-qryptonight.git
+[submodule "deps/py-cryptonight"]
+	path = deps/py-cryptonight
+	url = https://github.com/0xFF0/py-cryptonight.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "deps/xmr-stak"]
 	path = deps/xmr-stak
 	url = https://github.com/jleni/xmr-stak.git
+[submodule "py-cryptonight"]
+	path = py-cryptonight
+	url = https://github.com/0xFF0/py-cryptonight.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,15 +118,29 @@ if(WIN32 AND HWLOC_ENABLE)
 endif()
 
 if(NOT WIN32)
-    set(CMAKE_CXX_FLAGS "-march=native -mtune=native ${CMAKE_CXX_FLAGS} -msse2 -maes")
-    set(CMAKE_C_FLAGS "-march=native -mtune=native -fPIC ${CMAKE_C_FLAGS} -msse2 -maes")
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "armv7l")
+        set(CMAKE_CXX_FLAGS "-march=native -mtune=native ${CMAKE_CXX_FLAGS}")
+        set(CMAKE_C_FLAGS "-march=native -mtune=native -fPIC ${CMAKE_C_FLAGS}")
+    else ()
+        set(CMAKE_CXX_FLAGS "-march=native -mtune=native ${CMAKE_CXX_FLAGS} -msse2 -maes")
+        set(CMAKE_C_FLAGS "-march=native -mtune=native -fPIC ${CMAKE_C_FLAGS} -msse2 -maes")
+    endif()
 endif()
 
-include_directories(
-        ${CMAKE_CURRENT_SOURCE_DIR}/src/api
-        ${CMAKE_CURRENT_SOURCE_DIR}/src
-        ${CMAKE_CURRENT_SOURCE_DIR}/deps/xmr-stak
-)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "armv7l")
+	include_directories(
+			${CMAKE_CURRENT_SOURCE_DIR}/src/api
+			${CMAKE_CURRENT_SOURCE_DIR}/src
+			${CMAKE_CURRENT_SOURCE_DIR}/deps/py-cryptonight/src/cryptonight		
+	)
+
+else()
+	include_directories(
+			${CMAKE_CURRENT_SOURCE_DIR}/src/api
+			${CMAKE_CURRENT_SOURCE_DIR}/src
+			${CMAKE_CURRENT_SOURCE_DIR}/deps/xmr-stak		
+	)
+endif()
 
 file(GLOB LIB_QRYPTONIGHT_INCLUDES
         ${CMAKE_CURRENT_SOURCE_DIR}/src/qryptonight
@@ -141,16 +155,21 @@ file(GLOB_RECURSE LIB_QRYPTONIGHT_SRC
 file(GLOB_RECURSE TEST_QRYPTONIGHT_SRC
         "${CMAKE_CURRENT_SOURCE_DIR}/tests/cpp/*.cpp")
 
-file(GLOB REF_CRYPTONIGHT_SRC
-        ${CMAKE_CURRENT_SOURCE_DIR}/deps/xmr-stak/xmrstak/backend/cpu/crypto/*.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/deps/xmr-stak/xmrstak/backend/cpu/hwlocMemory.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/deps/xmr-stak/xmrstak/jconf.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/deps/xmr-stak/xmrstak/misc/console.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/deps/xmr-stak/xmrstak/misc/utility.cpp
-        )
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "armv7l")
+	file(GLOB REF_CRYPTONIGHT_C_SRC
+			${CMAKE_CURRENT_SOURCE_DIR}/deps/py-cryptonight/src/cryptonight/*.c )
+else()
+	file(GLOB REF_CRYPTONIGHT_SRC
+			${CMAKE_CURRENT_SOURCE_DIR}/deps/xmr-stak/xmrstak/backend/cpu/crypto/*.cpp
+			${CMAKE_CURRENT_SOURCE_DIR}/deps/xmr-stak/xmrstak/backend/cpu/hwlocMemory.cpp
+			${CMAKE_CURRENT_SOURCE_DIR}/deps/xmr-stak/xmrstak/jconf.cpp
+			${CMAKE_CURRENT_SOURCE_DIR}/deps/xmr-stak/xmrstak/misc/console.cpp
+			${CMAKE_CURRENT_SOURCE_DIR}/deps/xmr-stak/xmrstak/misc/utility.cpp
+			)
 
-file(GLOB REF_CRYPTONIGHT_C_SRC
-        ${CMAKE_CURRENT_SOURCE_DIR}/deps/xmr-stak/xmrstak/backend/cpu/crypto/*.c )
+	file(GLOB REF_CRYPTONIGHT_C_SRC
+			${CMAKE_CURRENT_SOURCE_DIR}/deps/xmr-stak/xmrstak/backend/cpu/crypto/*.c )
+endif()
 
 SET_SOURCE_FILES_PROPERTIES(${LIB_QRYPTONIGHT_SRC} PROPERTIES LANGUAGE CXX)
 SET_SOURCE_FILES_PROPERTIES(${TEST_QRYPTONIGHT_SRC} PROPERTIES LANGUAGE CXX)
@@ -159,7 +178,12 @@ SET_SOURCE_FILES_PROPERTIES(${TEST_QRYPTONIGHT_SRC} PROPERTIES LANGUAGE CXX)
 add_library(cryptonight-c-lib STATIC
         ${REF_CRYPTONIGHT_C_SRC}
         )
-set_property(TARGET cryptonight-c-lib PROPERTY C_STANDARD 99)
+		
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "armv7l")
+    set_property(TARGET cryptonight-c-lib PROPERTY C_STANDARD 11)
+else()
+    set_property(TARGET cryptonight-c-lib PROPERTY C_STANDARD 99)
+endif()
 
 if (BUILD_TESTS)
     message(STATUS "GTests enabled")
@@ -202,11 +226,18 @@ if (BUILD_TESTS)
     ###########################
     include(CTest)
 
-    add_executable(qryptonight_test
-            ${TEST_QRYPTONIGHT_SRC}
-            ${LIB_QRYPTONIGHT_SRC}
-            ${REF_CRYPTONIGHT_SRC}
-            )
+	if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "armv7l")
+		add_executable(qryptonight_test
+				${TEST_QRYPTONIGHT_SRC}
+				${LIB_QRYPTONIGHT_SRC}
+				)
+	else()
+		add_executable(qryptonight_test
+				${TEST_QRYPTONIGHT_SRC}
+				${LIB_QRYPTONIGHT_SRC}
+				${REF_CRYPTONIGHT_SRC}
+				)	
+	endif()
 
     target_include_directories( qryptonight_test PRIVATE
         ${LIB_QRYPTONIGHT_INCLUDES} ${Boost_INCLUDE_DIRS})
@@ -267,23 +298,44 @@ if (BUILD_PYTHON)
     set( CMAKE_SWIG_FLAGS ${CMAKE_SWIG_FLAGS} "-threads" )
 
     if(${CMAKE_VERSION} VERSION_LESS_EQUAL "3.10.3")
+		if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "armv7l")
         # Intentionally use a deprecated version to provide support for the raspberry pi
-        SWIG_ADD_MODULE(pyqryptonight
-                ${language}
-                ${SWIG_INTERFACE}
-                ${LIB_QRYPTONIGHT_SRC}
-                ${REF_CRYPTONIGHT_SRC}
-                )
+			SWIG_ADD_MODULE(pyqryptonight
+					${language}
+					${SWIG_INTERFACE}
+					${LIB_QRYPTONIGHT_SRC}
+					)
+		else()
+			SWIG_ADD_MODULE(pyqryptonight
+					${language}
+					${SWIG_INTERFACE}
+					${LIB_QRYPTONIGHT_SRC}
+					${REF_CRYPTONIGHT_SRC}
+					)
+		
+		endif()
     else()
-        SWIG_ADD_LIBRARY(pyqryptonight
-                LANGUAGE ${language}
-                OUTPUT_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
-                OUTFILE_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
-                TYPE MODULE
-                SOURCES ${SWIG_INTERFACE}
-                ${LIB_QRYPTONIGHT_SRC}
-                ${REF_CRYPTONIGHT_SRC}
-                )
+		if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "armv7l")
+			SWIG_ADD_LIBRARY(pyqryptonight
+					LANGUAGE ${language}
+					OUTPUT_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+					OUTFILE_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+					TYPE MODULE
+					SOURCES ${SWIG_INTERFACE}
+					${LIB_QRYPTONIGHT_SRC}
+					)
+		else()
+			SWIG_ADD_LIBRARY(pyqryptonight
+					LANGUAGE ${language}
+					OUTPUT_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+					OUTFILE_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+					TYPE MODULE
+					SOURCES ${SWIG_INTERFACE}
+					${LIB_QRYPTONIGHT_SRC}
+					${REF_CRYPTONIGHT_SRC}
+					)
+		
+		endif()
     endif()
 
     SWIG_LINK_LIBRARIES(pyqryptonight
@@ -345,13 +397,22 @@ if (BUILD_GO)
     message(STATUS "CMAKE_SWIG_OUTDIR: " ${CMAKE_SWIG_OUTDIR})
     message(STATUS "CMAKE_LIBRARY_OUTPUT_DIRECTORY: " ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 
+	if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "armv7l")
     # Intentionally use a deprecated version to provide support for the raspberry pi
-    SWIG_ADD_MODULE(goqryptonight
-            ${language}
-            ${SWIG_INTERFACE}
-            ${LIB_QRYPTONIGHT_SRC}
-            ${REF_CRYPTONIGHT_SRC}
-            )
+		SWIG_ADD_MODULE(goqryptonight
+				${language}
+				${SWIG_INTERFACE}
+				${LIB_QRYPTONIGHT_SRC}
+				)
+	else()
+		SWIG_ADD_MODULE(goqryptonight
+				${language}
+				${SWIG_INTERFACE}
+				${LIB_QRYPTONIGHT_SRC}
+				${REF_CRYPTONIGHT_SRC}
+				)
+	
+	endif()
 
     SWIG_LINK_LIBRARIES(goqryptonight
             ${SWIG_LANG_LIBRARIES}
@@ -390,11 +451,19 @@ if (BUILD_WEBASSEMBLY)
     set(JS_KYBINTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/src/jswrapper/jskybwrapper.cpp)
 
     message(STATUS "webassembly enabled")
-    add_library(jsqryptonight SHARED
-            ${JS_QRL_INTERFACE}
-            ${LIB_QRYPTONIGHT_SRC}
-            ${REF_CRYPTONIGHT_SRC}
-            )
+	if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "armv7l")
+		add_library(jsqryptonight SHARED
+				${JS_QRL_INTERFACE}
+				${LIB_QRYPTONIGHT_SRC}
+				)
+	else()
+		add_library(jsqryptonight SHARED
+				${JS_QRL_INTERFACE}
+				${LIB_QRYPTONIGHT_SRC}
+				${REF_CRYPTONIGHT_SRC}
+				)
+	
+	endif()
     target_include_directories( jsqryptonight PRIVATE
             ${LIB_QRL_INCLUDES} )
 

--- a/src/qryptonight/qryptonight.h
+++ b/src/qryptonight/qryptonight.h
@@ -27,29 +27,59 @@
 #include <vector>
 #include <string>
 #include <stdexcept>
-#include <xmrstak/backend/cpu/crypto/cryptonight_types.h>
 #include <atomic>
+
+#ifdef __arm__
+
+#include "hash-ops.h"
+
+#else
+	
+#include <xmrstak/backend/cpu/crypto/cryptonight_types.h>
+
+#endif
 
 class Qryptonight {
 public:
     Qryptonight();
     virtual ~Qryptonight();
 
-    bool isValid() { return _context != nullptr; }
-    std::string lastError()	{ return std::string(_last_msg.warning ? _last_msg.warning : ""); }
+    bool isValid() { 		
+		#ifdef __arm__
+		return true;
+		#else
+		return _context != nullptr; 
+		#endif
+	}
+	
+	
+    std::string lastError()	{ 
+		#ifndef __arm__
+		    return "";
+		#else
+		    return std::string(_last_msg.warning ? _last_msg.warning : ""); 
+		#endif
+	}
+	
 
     std::vector<uint8_t> hash(const std::vector<uint8_t>& input);
 
 protected:
+	#ifndef __arm__
     //Protected variables are prefixed with an underscore
     typedef void (*cn_hash_fn)(const void* input, size_t len, void* output, cryptonight_ctx* ctx0);
     static cn_hash_fn _hash_fn;
+	#endif
     
     static void init();
     static std::atomic_bool _jconf_initialized;
 
+	#ifndef __arm__
     alloc_msg _last_msg = { nullptr };
     cryptonight_ctx *_context;
+	#endif
 };
 
 #endif //QRYPTONIGHT_QRYPTONIGHT_H
+
+

--- a/src/qryptonight/qryptonight.h
+++ b/src/qryptonight/qryptonight.h
@@ -54,7 +54,7 @@ public:
 	
 	
     std::string lastError()	{ 
-		#ifndef __arm__
+		#ifdef __arm__
 		    return "";
 		#else
 		    return std::string(_last_msg.warning ? _last_msg.warning : ""); 


### PR DESCRIPTION
Raspberry Pi support for QRL

Tested with https://downloads.raspberrypi.org/raspios_armhf/images/raspios_armhf-2021-11-08/2021-10-30-raspios-bullseye-armhf.zip

This PR was developped during the QRL Hackathon 2022.

Instructions to try these modifications on the Raspberry Pi:

	# Update and Upgrade packages
	sudo apt update && sudo apt upgrade -y

	# Install Required dependencies
	sudo apt-get -y install swig4.0 python3-dev python3-pip build-essential pkg-config libssl-dev libffi-dev libhwloc-dev libboost-dev cmake libleveldb-dev libyaml-dev

	# Make sure setuptools is the latest
	pip3 install -U setuptools
	
	# Install modified libraries (i.e: qrandomx and qryptonight)
	git clone --recursive https://github.com/0xFF0/qrandomx
	git clone --recursive https://github.com/0xFF0/qryptonight
	cd qrandomx
	sudo python3 setup.py install
	cd ../qryptonight
	sudo python3 setup.py install
	
	# Download QRL
	git clone https://github.com/theQRL/QRL.git
	cd QRL

	# Remove qrandomx and qryptonight from the requirements
	sed -i 's/pyqryptonight/#pyqryptonight/g' setup.cfg
	sed -i 's/pyqrandomx/#pyqrandomx/g' setup.cfg
	
	# Temporary patch (https://github.com/theQRL/QRL/pull/1752)
	sed -i 's/protobuf==3.15.8/protobuf==3.20.1/g' setup.cfg
	
	# Install QRL
	sudo python3 setup.py install